### PR TITLE
Fix format error

### DIFF
--- a/repl_sessions/deja_fu.cljs
+++ b/repl_sessions/deja_fu.cljs
@@ -1,0 +1,8 @@
+(ns deja-fu
+  (:require [lambdaisland.deja-fu :as t]))
+
+
+(t/parse-local-date-time (str (goog.date.DateTime. (js/Date. 2021 0 1 23 59 ))))
+(t/parse-local-date-time (str (goog.date.DateTime. (js/Date. 2000 1 1 0 0 0 ))))
+
+

--- a/src/lambdaisland/deja_fu.cljs
+++ b/src/lambdaisland/deja_fu.cljs
@@ -129,8 +129,8 @@ not inside single quotes."))
   Format
   (format [obj]
     (if (and nanos (not= 0 nanos))
-      (format* obj "HH:mm:ss")
-      (format* obj "HH:mm:ss.SSSSSS")))
+      (format* obj "HH:mm:ss.SSSSSS")
+      (format* obj "HH:mm:ss")))
   (format [obj fmt]
     (format* obj fmt))
 

--- a/test/lambdaisland/deja_fu_test.cljs
+++ b/test/lambdaisland/deja_fu_test.cljs
@@ -46,8 +46,12 @@
 
 (t/parse-local-time (str (t/->LocalTime 11 1 1 1e6)))
 
-(deftest ^:kaocha/pending roundtrip 
-  (let [time-example (t/->LocalTime 11 1 1 1e6)]
+(deftest roundtrip 
+  (let [time-example (t/->LocalTime 11 1 1 0 )]
+    (is (= time-example (t/parse-local-time (str time-example))))))
+
+(deftest roundtrip-nanos 
+  (let [time-example (t/->LocalTime 11 1 1 1e6 )]
     (is (= time-example (t/parse-local-time (str time-example))))))
 
 (defspec test-time->string->time 

--- a/test/lambdaisland/deja_fu_test.cljs
+++ b/test/lambdaisland/deja_fu_test.cljs
@@ -5,7 +5,6 @@
             [clojure.test.check.properties :as prop :include-macros true]
             [clojure.test.check.clojure-test :refer [defspec]]
             [lambdaisland.deja-fu  :as t]
-            ;; [co.gaiwan.virtual-player.utils :as u]
             [goog.date.DateTime]
             [cljs-bean.core :refer [bean ->clj ->js]]))
 
@@ -58,7 +57,6 @@
                  s (gen/choose 0 60)]
                 (= (t/->LocalTime h m s nil)
                   (t/parse-local-time (str (t/->LocalTime h m s nil))) )))
-;; (t/->LocalDate)
 
 (defspec test-datetime->string->datetime 
   100
@@ -83,10 +81,6 @@
                      (t/parse-local-date (str d))))))
 
 #_(gen/sample (gen/choose 0 24))
-#_(t/parse-local-date-time (str (goog.date.DateTime. (js/Date. 2021 0 1 23 59 ))))
-#_(t/parse-local-date-time (str (goog.date.DateTime. (js/Date. 2000 1 1 0 0 0 ))))
-
-;; (defspec prop-)
 
 (deftest ^:kaocha/skip test-parse-invalid-local-time
   (testing "Verify invalid times are errors"


### PR DESCRIPTION

Fix what I'm pretty sure is a bug in the implementation of `Format/format` for `LocalTime`. Leaving this as a pull request so Arne can confirm.