### PR TITLE
`distance-in-words`: render approximate weeks; adjust range for months

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- `distance-in-words` now renders approximate weeks; month ranges were adjusted
+
 # 1.3.51 (2022-10-18 / 2d9d7f4)
 
 ## Added

--- a/src/lambdaisland/deja_fu.cljs
+++ b/src/lambdaisland/deja_fu.cljs
@@ -581,6 +581,7 @@ not inside single quotes."))
   "Word patterns, can be passed in for i18n"
   {:about-x-hours ["about 1 hour" "about {{count}} hours"]
    :about-x-months ["about 1 month" "about {{count}} months"]
+   :about-x-weeks ["about 1 week" "about {{count}} weeks"]
    :about-x-years ["about 1 year" "about {{count}} years"]
    :almost-x-years ["almost 1 year" "almost {{count}} years"]
    :half-a-minute "half a minute"
@@ -631,14 +632,14 @@ not inside single quotes."))
        (<= 45 delta-m 89)        (pattern :about-x-hours 1)
        ;; 90 mins up to 24 hours
        (<= 90 delta-m 1439)      (pattern :about-x-hours delta-h)
-       ;; 24 to 42 hours
-       (<= 1440 delta-m 2519)    (pattern :x-days 1)
-       ;; 30 to 60 days
-       (<= 2520 delta-m 43199)   (pattern :x-days (Math/round (/ delta-m 1440)))
-       ;; 60 to 365 days
-       (<= 43200 delta-m 86399)  (pattern :about-x-months (Math/round (/ delta-m 43200)))
-       ;; 60 days up to 365 days
-       (<= 86400 delta-m 525600) (pattern :x-months (Math/round (/ delta-m 43200)))
+       ;; 1 day to 7 days
+       (<= 1440 delta-m 10079)   (pattern :x-days (Math/round (/ delta-m 1440)))
+       ;; 1 week to 4 weeks
+       (<= 10080 delta-m 40319)  (pattern :about-x-weeks (Math/floor (/ delta-m 10080)))
+       ;; 28 days to 30 days
+       (<= 40320 delta-m 43199)   (pattern :about-x-months (Math/round (/ delta-m 40320)))
+       ;; 30 days to 365 days
+       (<= 43200 delta-m 525600) (pattern :x-months (Math/round (/ delta-m 43200)))
 
        :else
        (let [from-year                      (cond-> (:year from) (< 2 (:month from)) inc)

--- a/test/lambdaisland/deja_fu_test.cljs
+++ b/test/lambdaisland/deja_fu_test.cljs
@@ -135,11 +135,15 @@
          (fu/distance-in-words (fu/local-date-time 2022 1 1 0 0 0)
                                (fu/local-date-time 2022 1 2 2 1 50))))
 
-  (is (= "8 days"
+  (is (= "about 1 week"
          (fu/distance-in-words (fu/local-date-time 2022 1 1 0 0 0)
                                (fu/local-date-time 2022 1 9 0 1 50))))
 
-  (is (= "about 1 month"
+  (is (= "about 2 weeks"
+         (fu/distance-in-words (fu/local-date-time 2022 1 1 0 0 0)
+                               (fu/local-date-time 2022 1 15 0 0 0))))
+
+  (is (= "1 month"
          (fu/distance-in-words (fu/local-date-time 2022 1 1 0 0 0)
                                (fu/local-date-time 2022 2 2 2 1 50))))
 


### PR DESCRIPTION
Addresses #11. The ranges in `distance-in-words` has been modified to give approximate weeks. Some unit tests are updated to reflect this fact. The range for months was slightly adjusted.

**Example usage**

```clojure
(distance-in-words (local-date-time 2022 1 15 0 0 0) 
                   (local-date-time 2022 1 30 0 0 0))
;; => "about 2 weeks"
```

**Notes**

You'll notice that the unit test for months has been slightly modified. This is because the ranges I chose give us the following behavior, which I find desirable.

```clojure
(map (fn [n]
       (distance-in-words (local-date-time 2022 n 1 0 0 0)
                          (local-date-time 2022 (inc n) 1 0 0 0)))
     (range 1 12))

;; => ("1 month"
;;     "about 1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month"
;;     "1 month")

(distance-in-words (local-date-time 2022 12 1 0 0 0)
                   (local-date-time 2023  1 1 0 0 0))
;; => "1 month"
```